### PR TITLE
Make AWS SDK packages dependencies, not devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "name": "@nasa-gcn/dynamodb-autoincrement",
       "version": "1.0.0",
       "license": "Apache-2.0",
-      "devDependencies": {
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.188.0",
         "@aws-sdk/lib-dynamodb": "^3.188.0",
-        "@aws-sdk/util-dynamodb": "^3.188.0",
+        "@aws-sdk/util-dynamodb": "^3.188.0"
+      },
+      "devDependencies": {
         "@nasa-gcn/eslint-config-gitignore": "^0.0.1",
         "@shelf/jest-dynamodb": "^3.4.2",
         "@tsconfig/node14": "^1.0.3",
@@ -50,7 +53,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -60,14 +62,12 @@
     "node_modules/@aws-crypto/crc32/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
       "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -75,14 +75,12 @@
     "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
       "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/sha256-js": "^3.0.0",
@@ -97,14 +95,12 @@
     "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
       "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -114,14 +110,12 @@
     "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
       "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -129,14 +123,12 @@
     "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/util": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -146,14 +138,12 @@
     "node_modules/@aws-crypto/util/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.379.1.tgz",
       "integrity": "sha512-6a1nDXkWfMgXvjHNR4rqN+ujqJDKa2WRNC+8DBKfcumsRb/f8JLz8q+K7jOOEz3i0gsaXao1tyxe+lM5Y0NfeQ==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -203,7 +193,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.379.1.tgz",
       "integrity": "sha512-2N16TPnRcq+seNP8VY/Zq7kfnrUOrJMbVNpyDZWGe5Qglua3n8v/FzxmXFNI87MiSODq8IHtiXhggWhefCd+TA==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -247,7 +236,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.379.1.tgz",
       "integrity": "sha512-B6hZ2ysPyvafCMf6gls1jHI/IUviVZ4+TURpNfUBqThg/hZ1IMxc4BLkXca6VlgzYR+bWU8GKiClS9fFH6mu0g==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -291,7 +279,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.379.1.tgz",
       "integrity": "sha512-gEnKuk9bYjThvmxCgOgCn1qa+rRX8IgIRE2+xhbWhlpDanozhkDq9aMB5moX4tBNYQEmi1LtGD+JOvOoZRnToQ==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -339,7 +326,6 @@
       "version": "3.378.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.378.0.tgz",
       "integrity": "sha512-B2OVdO9kBClDwGgWTBLAQwFV8qYTYGyVujg++1FZFSFMt8ORFdZ5fNpErvJtiSjYiOOQMzyBeSNhKyYNXCiJjQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.378.0",
         "@smithy/property-provider": "^2.0.0",
@@ -354,7 +340,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.379.1.tgz",
       "integrity": "sha512-YhEsJIskzCFwIIKiMN9GSHQkgWwj/b7rq0ofhsXsCRimFtdVkmMlB9veE6vtFAuXpX/WOGWdlWek1az0V22uuw==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.378.0",
         "@aws-sdk/credential-provider-process": "3.378.0",
@@ -375,7 +360,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.379.1.tgz",
       "integrity": "sha512-39Y4OHKn6a8lY8YJhSLLw08aZytWxfvSjM4ObIEnE6hjLl8gsL9vROKKITsh3q6iGQ1EDSWMWZL50aOh3LJUIg==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.378.0",
         "@aws-sdk/credential-provider-ini": "3.379.1",
@@ -397,7 +381,6 @@
       "version": "3.378.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.378.0.tgz",
       "integrity": "sha512-KFTIy7u+wXj3eDua4rgS0tODzMnXtXhAm1RxzCW9FL5JLBBrd82ymCj1Dp72217Sw5Do6NjCnDTTNkCHZMA77w==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.378.0",
         "@smithy/property-provider": "^2.0.0",
@@ -413,7 +396,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.379.1.tgz",
       "integrity": "sha512-PhGtu1+JbUntYP/5CSfazQhWsjUBiksEuhg9fLhYl5OAgZVjVygbgoNVUz/gM7gZJSEMsasTazkn7yZVzO/k7w==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.379.1",
         "@aws-sdk/token-providers": "3.379.1",
@@ -431,7 +413,6 @@
       "version": "3.378.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.378.0.tgz",
       "integrity": "sha512-GWjydOszhc4xDF8xuPtBvboglXQr0gwCW1oHAvmLcOT38+Hd6qnKywnMSeoXYRPgoKfF9TkWQgW1jxplzCG0UA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.378.0",
         "@smithy/property-provider": "^2.0.0",
@@ -446,7 +427,6 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.310.0.tgz",
       "integrity": "sha512-y3wipforet41EDTI0vnzxILqwAGll1KfI5qcdX9pXF/WF1f+3frcOtPiWtQEZQpy4czRogKm3BHo70QBYAZxlQ==",
-      "dev": true,
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.5.0"
@@ -459,7 +439,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.379.1.tgz",
       "integrity": "sha512-SdHuRk9Jo0G9icW5uh36w1+RQ2U1c+dBBBVJSH7a17DzWAEsmcYYDUJ96PaA61clUgC7DI1a3jwSmgZnOszPhg==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/util-dynamodb": "3.379.1",
         "tslib": "^2.5.0"
@@ -475,7 +454,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.379.1.tgz",
       "integrity": "sha512-HpFF3Nb9csmg/j/trs4OhrQvthKFVz9lKkarGzxwYzaMqZ/xqFyPScJlZ41VgIkP+iP48IZVxAzLL/rsmsi/jA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/endpoint-cache": "3.310.0",
         "@aws-sdk/types": "3.378.0",
@@ -491,7 +469,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.379.1.tgz",
       "integrity": "sha512-LI4KpAFWNWVr2aH2vRVblr0Y8tvDz23lj8LOmbDmCrzd5M21nxuocI/8nEAQj55LiTIf9Zs+dHCdsyegnFXdrA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.378.0",
         "@smithy/protocol-http": "^2.0.1",
@@ -506,7 +483,6 @@
       "version": "3.378.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.378.0.tgz",
       "integrity": "sha512-l1DyaDLm3KeBMNMuANI3scWh8Xvu248x+vw6Z7ExWOhGXFmQ1MW7YvASg/SdxWkhlF9HmkkTif1LdMB22x6QDA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.378.0",
         "@smithy/types": "^2.0.2",
@@ -520,7 +496,6 @@
       "version": "3.378.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.378.0.tgz",
       "integrity": "sha512-mUMfHAz0oGNIWiTZHTVJb+I515Hqs2zx1j36Le4MMiiaMkPW1SRUF1FIwGuc1wh6E8jB5q+XfEMriDjRi4TZRA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.378.0",
         "@smithy/protocol-http": "^2.0.1",
@@ -535,7 +510,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.379.1.tgz",
       "integrity": "sha512-SK3gSyT0XbLiY12+AjLFYL9YngxOXHnZF3Z33Cdd4a+AUYrVBV7JBEEGD1Nlwrcmko+3XgaKlmgUaR5s91MYvg==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/middleware-signing": "3.379.1",
         "@aws-sdk/types": "3.378.0",
@@ -550,7 +524,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.379.1.tgz",
       "integrity": "sha512-kBk2ZUvR84EM4fICjr8K+Ykpf8SI1UzzPp2/UVYZ0X+4H/ZCjfSqohGRwHykMqeplne9qHSL7/rGJs1H3l3gPg==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.378.0",
         "@smithy/property-provider": "^2.0.0",
@@ -568,7 +541,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.379.1.tgz",
       "integrity": "sha512-4zIGeAIuutcRieAvovs82uBNhJBHuxfxaAUqrKiw49xUBG7xeNVUl+DYPSpbALbEIy4ujfwWCBOOWVCt6dyUZg==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.378.0",
         "@aws-sdk/util-endpoints": "3.378.0",
@@ -584,7 +556,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.379.1.tgz",
       "integrity": "sha512-NlYPkArJ7A/txCrjqqkje+4hsv7pSOqm+Qdx3BUIOc7PRYrBVs/XwThxUkGceSntVXoNlO8g9DFL0NY53/wb8Q==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/client-sso-oidc": "3.379.1",
         "@aws-sdk/types": "3.378.0",
@@ -601,7 +572,6 @@
       "version": "3.378.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.378.0.tgz",
       "integrity": "sha512-qP0CvR/ItgktmN8YXpGQglzzR/6s0nrsQ4zIfx3HMwpsBTwuouYahcCtF1Vr82P4NFcoDA412EJahJ2pIqEd+w==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.0.2",
         "tslib": "^2.5.0"
@@ -614,7 +584,6 @@
       "version": "3.379.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.379.1.tgz",
       "integrity": "sha512-789tTjt0yd8Uf8fBr4I56dYfLysncx3NlvuNhLqdLRWBpsGvfIixNZ9OSKxDpdJ0GASXMJklmyGadvGx/vXKZg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -626,7 +595,6 @@
       "version": "3.378.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.378.0.tgz",
       "integrity": "sha512-NU5C2l2xAXxpyB5nT0fIhahLPlJoJdzHWw4uC53KH9b4PrjHtgvgCN8beIsD3QxyfgeoM4A5J9Auo6WurfRnLw==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.378.0",
         "tslib": "^2.5.0"
@@ -639,7 +607,6 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
       "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -651,7 +618,6 @@
       "version": "3.378.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.378.0.tgz",
       "integrity": "sha512-FSCpagzftK1W+m7Ar6lpX7/Gr9y5P56nhFYz8U4EYQ4PkufS6czWX9YW+/FA5OYV0vlQ/SvPqMnzoHIPUNhZrQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.378.0",
         "@smithy/types": "^2.0.2",
@@ -663,7 +629,6 @@
       "version": "3.378.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.378.0.tgz",
       "integrity": "sha512-IdwVJV0E96MkJeFte4dlWqvB+oiqCiZ5lOlheY3W9NynTuuX0GGYNC8Y9yIsV8Oava1+ujpJq0ww6qXdYxmO4A==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.378.0",
         "@smithy/node-config-provider": "^2.0.1",
@@ -686,7 +651,6 @@
       "version": "3.259.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -2085,7 +2049,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.2.tgz",
       "integrity": "sha512-ln5Cob0mksym62sLr7NiPOSqJ0jKao4qjfcNLDdgINM1lQI12hXrZBlKdPHbXJqpKhKiECDgonMoqCM8bigq4g==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
@@ -2098,7 +2061,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.2.tgz",
       "integrity": "sha512-0kdsqBL6BdmSbdU6YaDkodVBMua5MuQQluC3nocJ7OJ6PnOuM7i2FEQHE46LBadLqT+CimlDSM+6j91uHNL1ng==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.1.0",
         "@smithy/util-config-provider": "^2.0.0",
@@ -2113,7 +2075,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.2.tgz",
       "integrity": "sha512-mbWFYEZ00LBRDk3WvcXViwpdpkJQcfrM3seuKzFxZnF6wIBLMwrcWcsj+OUC/1L+86m8aQY9imXMAaQsAoGxow==",
-      "dev": true,
       "dependencies": {
         "@smithy/node-config-provider": "^2.0.2",
         "@smithy/property-provider": "^2.0.2",
@@ -2129,7 +2090,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.2.tgz",
       "integrity": "sha512-PQZiKx7fMnNwx4zxcUCm82VjnqK6wV4MEHSmMy3taj5dKfXV782IjRGyaDT+8TsmNqVdZIkve5zLRAzh+7kOhA==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^2.1.0",
@@ -2141,7 +2101,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.2.tgz",
       "integrity": "sha512-Wo2m1RaiXNSLF4J3D62LpdSoj/YYb+6tn0H8is1tSrzr7eXAdiYVBc0wIa23N0wT4zmN0iG/yNY6gTCDQ6799A==",
-      "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^2.0.2",
         "@smithy/querystring-builder": "^2.0.2",
@@ -2154,7 +2113,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.2.tgz",
       "integrity": "sha512-JKDzZ1YVR7JzOBaJoWy3ToJCE86OQE6D4kOBvvVsu93a3lcF9kv6KYTKBYEWAjwOn/CpK4NH7mKB01OQ8H+aiA==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.1.0",
         "@smithy/util-buffer-from": "^2.0.0",
@@ -2169,7 +2127,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.2.tgz",
       "integrity": "sha512-inQZQ5gCO3WRWuXpsc1YJ4KBjsvj2qsoU32yTIKznBWTCQe/D5Dp+sSaysqBqxe0VTZ+8nFEHdUMWUX2BxQThw==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
@@ -2179,7 +2136,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
       "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2191,7 +2147,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.2.tgz",
       "integrity": "sha512-FmHlNfuvYgDZE3fIx0G3rD/wLXfAmBYE4mVc/w6d7RllA7TygPzq2pfHL1iCMzWkWTdoAVnt3h4aavAZnhaxEQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^2.0.2",
         "@smithy/types": "^2.1.0",
@@ -2205,7 +2160,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.2.tgz",
       "integrity": "sha512-ropE7/c+g22QeluZ+By/B/WvVep0UFreX+IeRMGIO7EbOUPgqtJRXpbJFdG6JKB1uC+CdaJLn4MnZnVBpcyjuA==",
-      "dev": true,
       "dependencies": {
         "@smithy/middleware-serde": "^2.0.2",
         "@smithy/types": "^2.1.0",
@@ -2221,7 +2175,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.2.tgz",
       "integrity": "sha512-wtBUXqtZVriiXppYaFkUrybAPhFVX7vebnW/yVPliLMWMcguOMS58qhOYPZe3t9Wki2+mASfyu+kO3An8lAg2A==",
-      "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^2.0.2",
         "@smithy/service-error-classification": "^2.0.0",
@@ -2239,7 +2192,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.2.tgz",
       "integrity": "sha512-Kw9xLdlueIaivUWslKB67WZ/cCUg3QnzYVIA3t5KfgsseEEuU4UxXw8NSTvIt71gqQloY+Um8ugS+idgxrWWnw==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
@@ -2252,7 +2204,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz",
       "integrity": "sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2264,7 +2215,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.2.tgz",
       "integrity": "sha512-9wVJccASfuCctNWrzR0zrDkf0ox3HCHGEhFlWL2LBoghUYuK28pVRBbG69wvnkhlHnB8dDZHagxH+Nq9dm7eWw==",
-      "dev": true,
       "dependencies": {
         "@smithy/property-provider": "^2.0.2",
         "@smithy/shared-ini-file-loader": "^2.0.2",
@@ -2279,7 +2229,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.2.tgz",
       "integrity": "sha512-lpZjmtmyZqSAtMPsbrLhb7XoAQ2kAHeuLY/csW6I2k+QyFvOk7cZeQsqEngWmZ9SJaeYiDCBINxAIM61i5WGLw==",
-      "dev": true,
       "dependencies": {
         "@smithy/abort-controller": "^2.0.2",
         "@smithy/protocol-http": "^2.0.2",
@@ -2295,7 +2244,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.2.tgz",
       "integrity": "sha512-DfaZ8cO+d/mgnMzIllcXcU4OYP+omiOl2LYdn/fTGpw/EAQSVzscYV2muV3sDDnuPYQ/r014hUqIxnF+pzh+SQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
@@ -2308,7 +2256,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
       "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
@@ -2321,7 +2268,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.2.tgz",
       "integrity": "sha512-H99LOMWEssfwqkOoTs4Y12UiZ7CTGQSX5Nrx5UkYgRbUEpC1GnnaprHiYrqclC58/xr4K76aNchdPyioxewMzA==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.1.0",
         "@smithy/util-uri-escape": "^2.0.0",
@@ -2335,7 +2281,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.2.tgz",
       "integrity": "sha512-L4VtKQ8O4/aWPQJbiFymbhAmxdfLnEaROh/Vs0OstJ7jtOZeBl2QJmuWY2V7hjt64W7V+tEn2sv6vVvnxkm/xQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
@@ -2348,7 +2293,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz",
       "integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==",
-      "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2357,7 +2301,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.2.tgz",
       "integrity": "sha512-2VkNOM/82u4vatVdK5nfusgGIlvR48Fkq6me17Oc+V1iyxfR/1x0pG6LzW0br1qlGtzBYFZKmDyviBRcPVFTVw==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
@@ -2370,7 +2313,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.2.tgz",
       "integrity": "sha512-YMooDEw/UmGxcXY4qWnSXkbPFsRloluSvyXVT678YPDN/K2AS1GzKfRsvSU7fbccOB4WF8MHZf2UqcRGEltE3Q==",
-      "dev": true,
       "dependencies": {
         "@smithy/eventstream-codec": "^2.0.2",
         "@smithy/is-array-buffer": "^2.0.0",
@@ -2389,7 +2331,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.2.tgz",
       "integrity": "sha512-mDfokI8WwLU5C0gcQ4ww/zJI/WLGSh2+vdIA42JRnjfYUjJNH/rKfX9YOnn2eBOxl3loATERVUqkHmKe+P8s2Q==",
-      "dev": true,
       "dependencies": {
         "@smithy/middleware-stack": "^2.0.0",
         "@smithy/types": "^2.1.0",
@@ -2404,7 +2345,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
       "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2416,7 +2356,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.2.tgz",
       "integrity": "sha512-X1mHCzrSVDlhVy7d3S7Vq+dTfYzwh4n7xGHhyJumu77nJqIss0lazVug85Pwo0DKIoO314wAOvMnBxNYDa+7wA==",
-      "dev": true,
       "dependencies": {
         "@smithy/querystring-parser": "^2.0.2",
         "@smithy/types": "^2.1.0",
@@ -2427,7 +2366,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
       "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
-      "dev": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2440,7 +2378,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
       "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       }
@@ -2449,7 +2386,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.0.0.tgz",
       "integrity": "sha512-ZV7Z/WHTMxHJe/xL/56qZwSUcl63/5aaPAGjkfynJm4poILjdD4GmFI+V+YWabh2WJIjwTKZ5PNsuvPQKt93Mg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2461,7 +2397,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
       "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-      "dev": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2474,7 +2409,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
       "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2486,7 +2420,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.2.tgz",
       "integrity": "sha512-c2tMMjb624XLuzmlRoZpnFOkejVxcgw3WQKdmgdGZYZapcLzXyC0H9JhnXMjQCt30GqLTlsILRNVBYwFRbw/4Q==",
-      "dev": true,
       "dependencies": {
         "@smithy/property-provider": "^2.0.2",
         "@smithy/types": "^2.1.0",
@@ -2501,7 +2434,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.2.tgz",
       "integrity": "sha512-gt7m5LLqUtEKldJLyc14DE4kb85vxwomvt9AfEMEvWM4VwfWS1kGJqiStZFb5KNqnQPXw8vvpgLTi8NrWAOXqg==",
-      "dev": true,
       "dependencies": {
         "@smithy/config-resolver": "^2.0.2",
         "@smithy/credential-provider-imds": "^2.0.2",
@@ -2518,7 +2450,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
       "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2530,7 +2461,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.0.tgz",
       "integrity": "sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2542,7 +2472,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.0.tgz",
       "integrity": "sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==",
-      "dev": true,
       "dependencies": {
         "@smithy/service-error-classification": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2555,7 +2484,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.2.tgz",
       "integrity": "sha512-Mg9IJcKIu4YKlbzvpp1KLvh4JZLdcPgpxk+LICuDwzZCfxe47R9enVK8dNEiuyiIGK2ExbfvzCVT8IBru62vZw==",
-      "dev": true,
       "dependencies": {
         "@smithy/fetch-http-handler": "^2.0.2",
         "@smithy/node-http-handler": "^2.0.2",
@@ -2574,7 +2502,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
       "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2586,7 +2513,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
       "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2599,7 +2525,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.2.tgz",
       "integrity": "sha512-7XCEVXDLguf3Og0NIF/KYEAHtrzNXmCdtEwMfOXr4iBKOUWYzNj91YB9O7tLrct8VGvysGA0x2xYzbxMbvF0QQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/abort-controller": "^2.0.2",
         "@smithy/types": "^2.1.0",
@@ -3360,8 +3285,7 @@
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4483,7 +4407,6 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
       "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "dev": true,
       "funding": [
         {
           "type": "paypal",
@@ -7716,7 +7639,6 @@
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
-      "dev": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -7942,8 +7864,7 @@
     "node_modules/obliterator": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
-      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
-      "dev": true
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -8853,8 +8774,7 @@
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "dev": true
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -9030,8 +8950,7 @@
     "node_modules/tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-      "dev": true
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -9168,7 +9087,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -29,9 +29,12 @@
   "engines": {
     "node": ">=16"
   },
-  "devDependencies": {
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.188.0",
     "@aws-sdk/lib-dynamodb": "^3.188.0",
-    "@aws-sdk/util-dynamodb": "^3.188.0",
+    "@aws-sdk/util-dynamodb": "^3.188.0"
+  },
+  "devDependencies": {
     "@nasa-gcn/eslint-config-gitignore": "^0.0.1",
     "@shelf/jest-dynamodb": "^3.4.2",
     "@tsconfig/node14": "^1.0.3",


### PR DESCRIPTION
They really are all dependencies. We only omitted them because of issues with Architect bundling, but that's Architect's problem, not ours.

And in any case we are now excluding the AWS SDK packages from bundling in our Remix/Architect projects.