### PR TITLE
Require node >= 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "node setup-dynamodb-local.mjs && jest"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.188.0",


### PR DESCRIPTION
The `setup-dynamodb-local.mjs` script, introduced in #14, requires the web fetch API, which requires Node >= 18.