### PR TITLE
Replace {counterTable,table}AttributeName with attributeName

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,13 +13,10 @@ export interface DynamoDBAutoIncrementProps {
   counterTableKey: Record<string, NativeAttributeValue>
 
   /** the name of the attribute in the table in which to store the last value of the counter */
-  counterTableAttributeName: string
+  attributeName: string
 
   /** the name of the table in which to store items */
   tableName: string
-
-  /** the name of the attribute used as the auto-incrementing partition key in the table in which to store items */
-  tableAttributeName: string
 
   /** the initial value of the counter */
   initialValue: number
@@ -93,11 +90,11 @@ export class DynamoDBAutoIncrement extends BaseDynamoDBAutoIncrement {
     return (
       (
         await this.props.doc.get({
-          AttributesToGet: [this.props.counterTableAttributeName],
+          AttributesToGet: [this.props.attributeName],
           Key: this.props.counterTableKey,
           TableName: this.props.counterTableName,
         })
-      ).Item?.[this.props.counterTableAttributeName] ?? undefined
+      ).Item?.[this.props.attributeName] ?? undefined
     )
   }
 
@@ -120,21 +117,21 @@ export class DynamoDBAutoIncrement extends BaseDynamoDBAutoIncrement {
       {
         ConditionExpression,
         ExpressionAttributeNames: {
-          '#counter': this.props.counterTableAttributeName,
+          '#counter': this.props.attributeName,
         },
         ExpressionAttributeValues,
         Item: {
           ...this.props.counterTableKey,
-          [this.props.counterTableAttributeName]: nextCounter,
+          [this.props.attributeName]: nextCounter,
         },
         TableName: this.props.counterTableName,
       },
       {
         ConditionExpression: 'attribute_not_exists(#counter)',
         ExpressionAttributeNames: {
-          '#counter': this.props.tableAttributeName,
+          '#counter': this.props.attributeName,
         },
-        Item: { [this.props.tableAttributeName]: nextCounter, ...item },
+        Item: { [this.props.attributeName]: nextCounter, ...item },
         TableName: this.props.tableName,
       },
     ]

--- a/src/test.ts
+++ b/src/test.ts
@@ -26,9 +26,8 @@ beforeAll(async () => {
     doc,
     counterTableName: 'autoincrement',
     counterTableKey: { tableName: 'widgets' },
-    counterTableAttributeName: 'counter',
     tableName: 'widgets',
-    tableAttributeName: 'widgetID',
+    attributeName: 'widgetID',
     initialValue: 1,
   }
   autoincrement = new DynamoDBAutoIncrement(options)
@@ -69,7 +68,7 @@ describe('dynamoDBAutoIncrement', () => {
       } else {
         await doc.put({
           TableName: 'autoincrement',
-          Item: { tableName: 'widgets', counter: lastID },
+          Item: { tableName: 'widgets', widgetID: lastID },
         })
         nextID = lastID + 1
       }
@@ -89,7 +88,7 @@ describe('dynamoDBAutoIncrement', () => {
       expect(autoincrementItems).toEqual([
         {
           tableName: 'widgets',
-          counter: nextID,
+          widgetID: nextID,
         },
       ])
     }


### PR DESCRIPTION
In practice, the version or counter attribute has the same name in both tables. Forcing that to be the case will make it simpler to implement versioning (#20).