### PR TITLE
Ignore Dependabot updates for AWS packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # Ignore AWS SDK packages because they are provided by the Lambda runtime.
+      - dependency-name: '@aws-sdk/*'


### PR DESCRIPTION
These packages should match the versions provided by the Lambda runtime.